### PR TITLE
Enable buyer to filter offers by date

### DIFF
--- a/app/controllers/api/v1/buyers/offers_controller.rb
+++ b/app/controllers/api/v1/buyers/offers_controller.rb
@@ -2,7 +2,11 @@ class Api::V1::Buyers::OffersController < ApplicationController
   before_action :authenticate_buyer!, :buyer_signed_in?
 
   def index
-    render json: current_buyer.offers
+    if params[:date]
+      render json: current_buyer.offers.where(date: Date.parse(params[:date]))
+    else
+      render json: current_buyer.offers
+    end
   end
 
   def update

--- a/spec/requests/api/v1/buyers/buyer_offers_by_id_spec.rb
+++ b/spec/requests/api/v1/buyers/buyer_offers_by_id_spec.rb
@@ -47,5 +47,51 @@ RSpec.describe 'buyer endpoints' do
       expect(second_buyer_offer[:merch_split]).to eq(offer_2.merch_split)
       expect(second_buyer_offer[:artist_name]).to eq(offer_2.artist_name)
     end
+    it 'returns all venues associated with a buyer by date' do
+      buyer = Fabricate(:buyer)
+      artist = Fabricate(:artist)
+      venue = Fabricate(:venue)
+      sign_in buyer
+
+      offer_1 = Fabricate(:offer, artist_id: artist.id, venue_id: venue.id, buyer_id: buyer.id, date: Date.parse('1967-10-31'))
+      offer_2 = Fabricate(:offer, artist_id: artist.id, venue_id: venue.id, buyer_id: buyer.id, date: Date.parse('1969-10-31'))
+      offer_3 = Fabricate(:offer, artist_id: artist.id, venue_id: venue.id, buyer_id: buyer.id, date: Date.parse('1969-10-31'))
+
+      get "/api/v1/buyers/#{buyer.id}/offers?date=1969-10-31"
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+
+      buyer_offers = JSON.parse(response.body, symbolize_names: true)
+      first_buyer_offer = buyer_offers.first
+      second_buyer_offer = buyer_offers.last
+
+      expect(buyer_offers).to be_an(Array)
+      expect(buyer_offers.length).to eq(2)
+
+      expect(first_buyer_offer[:status]).to eq(offer_2.status)
+      expect(first_buyer_offer[:guarantee]).to eq(offer_2.guarantee)
+      expect(Date.parse(first_buyer_offer[:date])).to eq(offer_2.date)
+      expect(first_buyer_offer[:bonuses]).to eq(offer_2.bonuses)
+      expect(first_buyer_offer[:radius_clause]).to eq(offer_2.radius_clause)
+      expect(first_buyer_offer[:total_expenses]).to eq(offer_2.total_expenses)
+      expect(first_buyer_offer[:gross_potential]).to eq(offer_2.gross_potential)
+      expect(first_buyer_offer[:door_times]).to eq(offer_2.door_times)
+      expect(first_buyer_offer[:age_range]).to eq(offer_2.age_range)
+      expect(first_buyer_offer[:merch_split]).to eq(offer_2.merch_split)
+      expect(first_buyer_offer[:artist_name]).to eq(offer_2.artist_name)
+
+      expect(second_buyer_offer[:status]).to eq(offer_3.status)
+      expect(second_buyer_offer[:guarantee]).to eq(offer_3.guarantee)
+      expect(Date.parse(second_buyer_offer[:date])).to eq(offer_3.date)
+      expect(second_buyer_offer[:bonuses]).to eq(offer_3.bonuses)
+      expect(second_buyer_offer[:radius_clause]).to eq(offer_3.radius_clause)
+      expect(second_buyer_offer[:total_expenses]).to eq(offer_3.total_expenses)
+      expect(second_buyer_offer[:gross_potential]).to eq(offer_3.gross_potential)
+      expect(second_buyer_offer[:door_times]).to eq(offer_3.door_times)
+      expect(second_buyer_offer[:age_range]).to eq(offer_3.age_range)
+      expect(second_buyer_offer[:merch_split]).to eq(offer_3.merch_split)
+      expect(second_buyer_offer[:artist_name]).to eq(offer_3.artist_name)
+    end
   end
 end


### PR DESCRIPTION
## Pull Request Template

x Wrote Tests
x Implemented
x Reviewed


# Necessary checkmarks:
- [x] All Tests are Passing

- [x] The code will run locally

## Type of change
- [x] New feature
- [ ] Bug Fix
- [ ] Refactor


# Implements/Fixes:
* description: buyers can now view offers by date
closes #54 

# Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Please Include a link to a gif of your feelings about this branch
Link: https://media.giphy.com/media/cPNXOm7ln8HwK7UcbV/giphy.gif
