### PR TITLE
Prevent duplicate artist genre rows from being created

### DIFF
--- a/app/services/artist_genre_linker.rb
+++ b/app/services/artist_genre_linker.rb
@@ -3,7 +3,7 @@ class ArtistGenreLinker
     genre_list = genres.split(', ')
     genre_list.each do | genre |
       stored_genre = Genre.find_or_create_by(name: genre.downcase)
-      ArtistGenre.create(artist_id: artist.id, genre_id: stored_genre.id)
+      ArtistGenre.where(artist_id: artist.id).find_or_create_by(genre_id: stored_genre.id)
     end
   end
 end

--- a/spec/requests/api/v1/artists/a_buyer_creates_an_artist_spec.rb
+++ b/spec/requests/api/v1/artists/a_buyer_creates_an_artist_spec.rb
@@ -94,5 +94,32 @@ describe 'POST /api/v1/artists' do
 
       expect(new_artist[:message]).to eq('Invalid artist parameters.')
     end
+    it 'does not create duplicate artist_genres' do
+      artist_1 = Fabricate(:artist, name: 'Bad')
+      artist_2 = Fabricate(:artist, name: 'Blad')
+
+      genre_1 = artist_1.genres.create(name: 'rock')
+      artist_2.artist_genres.create(genre_id: genre_1.id)
+
+      artist_payload = {  name: 'Bad',
+                          agency: 'Heavy Metal Boiz',
+                          songkick_id: 1234,
+                          image_url: 'yowutup',
+                          popularity: 12,
+                          spotify_id: 'yowutup',
+                          spotify_url: 'yowutup',
+                          spotify_followers: 12222,
+                          genres: 'Rock'
+                        }
+
+      expect(ArtistGenre.count).to eq(2)
+
+      post '/api/v1/artists', params: artist_payload.to_json, headers: {'Content-Type': 'application/json'}
+
+      expect(ArtistGenre.count).to eq(2)
+
+      expect(response).to be_successful
+      expect(response.status).to eq(201)
+    end
   end
 end


### PR DESCRIPTION
## Pull Request Template

x Wrote Tests
x Implemented
x Reviewed


# Necessary checkmarks:
- [x] All Tests are Passing

- [x] The code will run locally

## Type of change
- [ ] New feature
- [x] Bug Fix
- [ ] Refactor


# Implements/Fixes:
* description: prevents duplicate join table rows between artist and genre from being created

# Check the correct boxes

- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Please Include a link to a gif of your feelings about this branch
Link: https://media.giphy.com/media/oVjZP4roPdWdbpmLu8/giphy.gif
